### PR TITLE
Move command runner parameters to config

### DIFF
--- a/igogpt.go
+++ b/igogpt.go
@@ -192,7 +192,13 @@ func Auto(ctx context.Context, cfg *Config) error {
 
 	// Command runner
 	ctx, exit := context.WithCancel(ctx)
-	runner := command.New(bingChat, cfg.GoogleKey, cfg.GoogleCX, cfg.Output, exit)
+	runner := command.New(&command.Config{
+		Exit:      exit,
+		Output:    cfg.Output,
+		Bing:      bingChat,
+		GoogleKey: cfg.GoogleKey,
+		GoogleCX:  cfg.GoogleCX,
+	})
 
 	send := prmpt
 	log.Println("starting auto mode")
@@ -310,7 +316,14 @@ func Pair(ctx context.Context, cfg *Config) error {
 // Cmd runs a command and returns the result
 func Cmd(ctx context.Context, cfg *Config) error {
 	// Bing chat not being available in this mode
-	runner := command.New(&notAvailable{}, cfg.GoogleKey, cfg.GoogleCX, cfg.Output, func() {})
+	runner := command.New(&command.Config{
+		Exit:      func() {},
+		Output:    cfg.Output,
+		Bing:      &notAvailable{},
+		GoogleKey: cfg.GoogleKey,
+		GoogleCX:  cfg.GoogleCX,
+	})
+
 	// TODO: custom parameter for json input
 	result := runner.Run(ctx, cfg.Prompt)
 	out, err := json.MarshalIndent(result, "", "  ")

--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -18,25 +18,32 @@ import (
 )
 
 type runner struct {
-	bing     io.ReadWriter
-	output   string
 	commands map[string]Command
 }
 
+// Config represents the configuration for a command runner.
+type Config struct {
+	Exit      func()
+	Output    string
+	Bing      io.ReadWriter
+	GoogleKey string
+	GoogleCX  string
+}
+
 // New returns a new command runner.
-func New(bing io.ReadWriter, googleKey, googleCX, output string, exit func()) *runner {
+func New(cfg *Config) *runner {
 	cmds := []Command{
-		&BashCommand{output: output},
-		&BingCommand{chat: bing},
-		&GoogleCommand{key: googleKey, cx: googleCX},
+		&BashCommand{output: cfg.Output},
+		&BingCommand{chat: cfg.Bing},
+		&GoogleCommand{key: cfg.GoogleKey, cx: cfg.GoogleCX},
 		&WebCommand{},
 		NewNopCommand("talk"), NewNopCommand("think"),
 		// File commands
-		&ReadFileCommand{output: output},
-		&WriteFileCommand{output: output},
-		&DeleteFileCommand{output: output},
-		&ListFilesCommand{output: output},
-		&ExitCommand{exit: exit},
+		&ReadFileCommand{output: cfg.Output},
+		&WriteFileCommand{output: cfg.Output},
+		&DeleteFileCommand{output: cfg.Output},
+		&ListFilesCommand{output: cfg.Output},
+		&ExitCommand{exit: cfg.Exit},
 	}
 
 	lookupCmds := map[string]Command{}
@@ -44,8 +51,6 @@ func New(bing io.ReadWriter, googleKey, googleCX, output string, exit func()) *r
 		lookupCmds[cmd.Name()] = cmd
 	}
 	return &runner{
-		bing:     bing,
-		output:   output,
 		commands: lookupCmds,
 	}
 }


### PR DESCRIPTION
Configuration parameters are going to be moved to a config file. This way is easier to increase the list and add optional parameters.